### PR TITLE
workaround for non-configurable props in the polyfill

### DIFF
--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -19,6 +19,10 @@ const globals = {
 };
 export default function installPolyfills() {
   for (const name in globals) {
+    let descriptor = Object.getOwnPropertyDescriptor(globalThis, name);
+    if (descriptor && !descriptor.configurable) {
+      continue;
+    }
     Object.defineProperty(globalThis, name, {
       enumerable: true,
       configurable: true,


### PR DESCRIPTION
after bun hit 0.8.0 running a build and subsequently trying to run `bun ./build/index.js` resulted in a
```shell
➜ bun ./build/index.js
572 | }, globals = {
573 |   File
574 | };
575 | function installPolyfills() {
576 |   for (let name in globals)
577 |     Object.defineProperty(globalThis, name, {
        ^
TypeError: Attempting to change configurable attribute of unconfigurable property.
      at installPolyfills (/Users/vladimir/Dev_Projects/lime812-via-bunx/build/index.js:577:4)
      at /Users/vladimir/Dev_Projects/lime812-via-bunx/build/index.js:587:
```

i'm adding a check in a polyfill loop to skip any not configurable properties