### PR TITLE
fix cached headers getting modified

### DIFF
--- a/src/sirv.js
+++ b/src/sirv.js
@@ -231,6 +231,12 @@ export default function (dir, opts = {}) {
       return new Response(null, { status: 304 });
     }
 
+    data = {
+      ...data,
+      // clone a new headers to prevent the cached one getting modified
+      headers: new Headers(data.headers)
+    }
+
     if (gzips || brots) {
       data.headers.append("Vary", "Accept-Encoding");
     }


### PR DESCRIPTION
if a response is cached and there is no `accept-encoding` header in the request, then a `"Accept-Encoding"` will be **appended to the cached response**, if more and more request (eg: benchmark) does not have `accept-encoding` header, the response header will grow until nobody can proccess

![image](https://github.com/gornostay25/svelte-adapter-bun/assets/3667594/c2a758ae-12a8-49fc-acee-ff671aedd661)
