### PR TITLE
Get ORIGIN from env var and default to https

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -19,8 +19,8 @@ const xff_depth = parseInt(env("XFF_DEPTH", build_options.xff_depth ?? 1));
 const origin = env('ORIGIN', undefined);
 
 const address_header = env("ADDRESS_HEADER", "").toLowerCase();
-const protocol_header = env("PROTOCOL_HEADER", "X-Forwarded-Proto").toLowerCase();
-const host_header = env("HOST_HEADER", "X-Forwarded-Host").toLowerCase();
+const protocol_header = env("PROTOCOL_HEADER", "").toLowerCase();
+const host_header = env("HOST_HEADER", "").toLowerCase();
 
 /** @param {boolean} assets */
 export default function (assets) {
@@ -95,12 +95,10 @@ function serve(path, client = false) {
 /**@param {Request} req */
 function ssr(req) {
   let request = req;
-  if (build_options.dynamic_origin ?? false) {
-    let url = req.url;
-    let path = url.slice(url.split("/", 3).join("/").length);
-    let base = origin || get_origin(req.headers);
-    request = new Request(base + path, req);
-  }
+  let url = req.url;
+  let path = url.slice(url.split("/", 3).join("/").length);
+  let base = origin || get_origin(req.headers);
+  request = new Request(base + path, req);
 
   if (address_header && !request.headers.has(address_header)) {
     throw new Error(
@@ -149,7 +147,7 @@ function ssr(req) {
  * @returns {string}
  */
 function get_origin(headers) {
-  const protocol = (protocol_header && headers.get(protocol_header)) || "http";
+  const protocol = (protocol_header && headers.get(protocol_header)) || "https";
   const host = headers.get(host_header);
   return `${protocol}://${host}`;
 }

--- a/src/handler.js
+++ b/src/handler.js
@@ -16,6 +16,7 @@ const server = new Server(manifest);
 await server.init({ env: (Bun || process).env });
 
 const xff_depth = parseInt(env("XFF_DEPTH", build_options.xff_depth ?? 1));
+const origin = env('ORIGIN', undefined);
 
 const address_header = env("ADDRESS_HEADER", "").toLowerCase();
 const protocol_header = env("PROTOCOL_HEADER", "X-Forwarded-Proto").toLowerCase();
@@ -97,8 +98,8 @@ function ssr(req) {
   if (build_options.dynamic_origin ?? false) {
     let url = req.url;
     let path = url.slice(url.split("/", 3).join("/").length);
-    let origin = get_origin(req.headers);
-    request = new Request(origin + path, req);
+    let base = origin || get_origin(req.headers);
+    request = new Request(base + path, req);
   }
 
   if (address_header && !request.headers.has(address_header)) {


### PR DESCRIPTION
This fixes #33 but also renders the config option `dynamic_origin` obsolete. If ORIGIN is set as an env var, it is used, otherwise origin is dynamic. Removed default values for `protocol_header` and `host_header` and set default origin protocol to `https`. This makes the adapter behave similar to the official node adapter.