### PR TITLE
Add handler.js to entrypoints

### DIFF
--- a/build.js
+++ b/build.js
@@ -2,7 +2,7 @@ import fs from "fs/promises";
 
 await fs.rm("./files", { recursive: true, force: true });
 await Bun.build({
-  entrypoints: ["src/index.js", "src/mime.conf.js"],
+  entrypoints: ["src/index.js", "src/handler.js", "src/mime.conf.js"],
   outdir: "./files",
   splitting: true,
   external: ["SERVER", "MANIFEST"],


### PR DESCRIPTION
This change exposes the handler function (wrapper) to allow running custom servers.
Exposing a handler function directly like in the adapter-node package would be a potential improvement.
Resolves #28 and #37.