### PR TITLE
Add prestart and poststart as adapter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ export default {
       },
       dynamic_origin: true,
       xff_depth: 1,
+      prestart: "",
+      poststart: "",
     }),
   },
 };
@@ -106,6 +108,14 @@ If enabled use `PROTOCOL_HEADER` `HOST_HEADER` like origin. Default: `false`
 ### xff_depth
 
 The default value of XFF_DEPTH if environment is not set. Default: `1`
+
+### prestart
+
+`prestart` script field that will be added to built `package.json`. Default: `""`
+
+### postart
+
+`poststart` script field that will be added to built `package.json`. Default: `""`
 
 ## :spider_web: WebSocket Server
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -78,6 +78,19 @@ interface AdapterOptions extends BuildOptions {
    * @default ''
    */
   envPrefix?: string;
+
+  /**
+   * If you need to add a `prestart` script to the `package.json` of the build folder, you can specify it here.
+   * @default ''
+   */
+  prestart?: string;
+
+  /**
+   * If you need to add a `postscript` script to the `package.json` of the build folder, you can specify it here.
+   * @default ''
+   */
+  poststart?: string;
+
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -26,6 +26,8 @@ export default function (opts = {}) {
     dynamic_origin = false,
     xff_depth = 1,
     assets = true,
+    prestart = "",
+    poststart = "",
   } = opts;
   return {
     name: "svelte-adapter-bun",
@@ -76,6 +78,8 @@ export default function (opts = {}) {
         private: true,
         main: "index.js",
         scripts: {
+          prestart: prestart,
+          poststart: poststart,
           start: "bun ./index.js",
         },
         dependencies: { cookie: "latest", devalue: "latest", "set-cookie-parser": "latest" },


### PR DESCRIPTION
This PR will add `prestart` and `postart` as adapter options and pass them them to generated `package.json`  

Example use cases:
- When using `bun:sqlite` I want to save sqlite database on it's own folder. With `prestart` script I can run `mkdir ./database/` automatically.
- `prestart` allows this makes possible to run some migration script before starting production version of sveltekit app.


[npm Docs - prestart & poststart](https://docs.npmjs.com/cli/v10/using-npm/scripts#npm-start)

Example how to use:

```
// svelte.config.js

import adapter from "svelte-adapter-bun";
const config = {
  kit: {
    adapter: adapter({
      prestart: "mkdir ./database",
      poststart: "echo 'poststart'",
    })
  }
};
```

```̈́
// generated package.json in build folder

"scripts": {
  "prestart": "mkdir ./database",
  "poststart": "echo 'poststart'",
  "start": "bun ./index.js"
},
```
