### PR TITLE
fix: respect `out` config in the final log to the user

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ export default function (opts = {}) {
 
       writeFileSync(`${out}/package.json`, JSON.stringify(package_data, null, "\t"));
 
-      builder.log.success("Start server with: bun ./build/index.js");
+      builder.log.success(`Start server with: bun ./${out}/index.js`);
     },
   };
 }


### PR DESCRIPTION
![svelte-adapter-bun](https://github.com/gornostay25/svelte-adapter-bun/assets/25263210/1279f9ac-a645-4e0d-8dea-dddeb1c2eb9f)
