### PR TITLE
fix: Correct amount of bytes for HTTP range responses

### DIFF
--- a/src/sirv.js
+++ b/src/sirv.js
@@ -91,7 +91,7 @@ function send(req, data) {
   }
 
   if (opts.range) {
-    return new Response(Bun.file(data.abs).slice(opts.start, opts.end), {
+    return new Response(Bun.file(data.abs).slice(opts.start, opts.end + 1), {
       headers: data.headers,
       status: code,
     });


### PR DESCRIPTION
The HTTP "Range" and "Content-Range" headers use inclusive start and end indices.
See [RFC 7233](https://www.rfc-editor.org/rfc/rfc7233).

Bun file slices, however, use an exclusive end index. The code to construct the answer did not reflect that.