### PR TITLE
fix: dependency version specifier

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ export default function (opts = {}) {
         scripts: {
           start: "bun ./index.js",
         },
-        dependencies: { cookie: "^1", devalue: "^5", "set-cookie-parser": "^2" },
+        dependencies: { cookie: "^0", devalue: "^5", "set-cookie-parser": "^2" },
       };
 
       try {

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ export default function (opts = {}) {
         scripts: {
           start: "bun ./index.js",
         },
-        dependencies: { cookie: "latest", devalue: "latest", "set-cookie-parser": "latest" },
+        dependencies: { cookie: "^1", devalue: "^5", "set-cookie-parser": "^2" },
       };
 
       try {


### PR DESCRIPTION
Set's major version for dependencies in the generated `package.json`.

This is needed, since the 1.x release of `cookie` broke my app.

Also we should probably merge the versions from the lockfile - not the `package.json` 👍🏻 