### PR TITLE
feat: read env SOCKET_PATH

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -1,4 +1,5 @@
 const expected = new Set([
+  "SOCKET_PATH",
   "HOST",
   "PORT",
   "ORIGIN",

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import { serve } from "bun";
 import { build_options, env } from "./env.js";
 import handler from "./handler.js";
 
+const unix = env("SOCKET_PATH", false);
 const hostname = env("HOST", "0.0.0.0");
 const port = parseInt(env("PORT", 3000));
 const maxRequestBodySize = parseInt(env("BODY_SIZE_LIMIT", undefined));
@@ -13,8 +14,7 @@ const serverOptions = {
   baseURI: env("ORIGIN", undefined),
   maxRequestBodySize: isNaN(maxRequestBodySize) ? undefined : maxRequestBodySize,
   fetch: httpserver,
-  hostname,
-  port,
+  ...(unix ? { unix } : { hostname, port }),
   development: env("SERVERDEV", build_options.development ?? false),
   error(error) {
     console.error(error);
@@ -24,5 +24,7 @@ const serverOptions = {
 
 websocket ? (serverOptions.websocket = websocket) : 0;
 
-console.info(`Listening on ${hostname + ":" + port}` + (websocket ? " (Websocket)" : ""));
+console.info(
+  `Listening on ${unix ? unix : hostname + ":" + port}` + (websocket ? " (Websocket)" : ""),
+);
 serve(serverOptions);


### PR DESCRIPTION
Allows to accept connections on a specified socket path. Consistent with adapter-node [behavior](https://svelte.dev/docs/kit/adapter-node#Environment-variables-PORT-HOST-and-SOCKET_PATH).
