### PR TITLE
fix: return websocket from get_hooks when hooks.ts is present

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -147,7 +147,7 @@ async function patchServerWebsocketHandler(path: string) {
       '$1$3websocket: $2.websocket || null,'
     )
     .replace(/(async function get_hooks\(\) {)/, '$1let websocket;')
-    .replace(/(\({handle,)((.|\s)*?{)/, '$1websocket,$2websocket,')
+    .replace(/(\({handle,)((.|\s)*?return {)/, '$1websocket,$2websocket,')
     .replace(
       /(async init\({ env, read }\) {)/,
       'websocket() {return this.#options.hooks.websocket}\n$1'


### PR DESCRIPTION
websocket is incorrectly placed in the chunk from hooks.ts instead of being returned
https://github.com/gornostay25/svelte-adapter-bun/issues/77#issuecomment-3369279385
